### PR TITLE
Use custom "og:title" in social cards

### DIFF
--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -76,7 +76,8 @@ def get_tags(
     title_excluding_html = get_title(context["title"], skip_html_tags=True)
 
     # Parse/walk doctree for metadata (tag/description)
-    description = get_description(doctree, desc_len, [title, title_excluding_html])
+    description_body = get_description(doctree, desc_len, [title, title_excluding_html])
+    description = fields.get("og:description", description_body)
 
     # title tag
     tags["og:title"] = title

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -161,7 +161,8 @@ def get_tags(
             description = description[:description_max_length].strip() + "..."
 
         # Page title
-        pagetitle = title
+        pagetitle = fields.get("og:title", title)
+
         if len(pagetitle) > DEFAULT_PAGE_LENGTH_SOCIAL_CARDS:
             pagetitle = pagetitle[:DEFAULT_PAGE_LENGTH_SOCIAL_CARDS] + "..."
 


### PR DESCRIPTION
If I override the opengraph title on a page, it doesn't change the title in the image preview.

This was motivated because I have titles with emojis, which matplotlib can't display correctly (shows a rectangle). So I want to change the title (without emojis) both in the og tag and in the social card.