### PR TITLE
Allow setting a canonical URL via ``ogp_canonical_url``

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Users hosting documentation on Read The Docs *do not* need to set any of the fol
     * This is not required. List of custom html snippets to insert.
 * `ogp_enable_meta_description`
     * This is not required. When `True`, generates `<meta name="description" content="...">` from the page.
+* `ogp_canonical_url`
+    * This is not required. This option can be used to override the "canonical" URL for the page,
+      and is used for `og:url` and the URL text in generated social media preview cards.
+      It is most useful with versioned documentation, where you intend to set the "stable"
+      or "latest" version as the canonical location of each page, similarly to `rel="canonical"`.
+      If not set, the option defaults to the value of `ogp_site_url`. 
 
 ## Example Config
 

--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
     from matplotlib.figure import Figure
     from matplotlib.text import Text
-    from sphinx.config import Config
     from sphinx.environment import BuildEnvironment
 
     PltObjects: TypeAlias = tuple[Figure, Text, Text, Text, Text]
@@ -68,8 +67,8 @@ def create_social_card(
     *,
     srcdir: str | Path,
     outdir: str | Path,
-    config: Config,
     env: BuildEnvironment,
+    html_logo: str | None = None,
 ) -> Path:
     """Create a social preview card according to page metadata.
 
@@ -105,8 +104,8 @@ def create_social_card(
     # Large image to the top right
     if cs_image := config_social.get("image"):
         kwargs_fig["image"] = Path(srcdir) / cs_image
-    elif config.html_logo:
-        kwargs_fig["image"] = Path(srcdir) / config.html_logo
+    elif html_logo:
+        kwargs_fig["image"] = Path(srcdir) / html_logo
 
     # Mini image to the bottom right
     if cs_image_mini := config_social.get("image_mini"):
@@ -133,10 +132,10 @@ def create_social_card(
             kwargs_fig[img] = None
 
     # These are passed directly from the user configuration to our plotting function
-    pass_through_config = ["text_color", "line_color", "background_color", "font"]
+    pass_through_config = ("text_color", "line_color", "background_color", "font")
     for config in pass_through_config:
-        if config_social.get(config):
-            kwargs_fig[config] = config_social.get(config)
+        if cs_config := config_social.get(config):
+            kwargs_fig[config] = cs_config
 
     # Generate the image and store the matplotlib objects so that we can re-use them
     try:


### PR DESCRIPTION
This PR builds on #133, only the final commit is new.

We introduce a new setting, ``ogp_canonical_url``, which defines the canonical or permanent URL for a webpage, similarly to `rel="canonical"`. The motivating example is Python's documentation, where we have multiple different sites (e.g. 3.12, 3.13, 3.14), but we want search engines and other tools to use `docs.python.org/3/` as the canonical URL.

I had considered solving this problem another way, by allowing the URL only for images to be changed, but I believe that this solution is conceptually better, and maps more closely to the description of `og:url` in the Open Graph Protocol specification.

Please let me know your thoughts and feedback!

A